### PR TITLE
Fix broken kinds on /builds/kind and /builds/kindbyviewname

### DIFF
--- a/ApiFun/Program.cs
+++ b/ApiFun/Program.cs
@@ -311,7 +311,7 @@ namespace Dashboard.ApiFun
             var date = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
             var populator = new BuildTablePopulator(account.CreateCloudTableClient(), CreateClient(), Console.Out);
             var table = account.CreateCloudTableClient().GetTableReference(AzureConstants.TableNames.BuildResultDate);
-            foreach (var entity in buildUtil.GetBuildResults(date, ClassificationKind.Unknown, AzureUtil.ViewNameAll))
+            foreach (var entity in buildUtil.GetBuildResultsByKindName(date, BuildResultClassification.Unknown.Name, AzureUtil.ViewNameAll))
             {
                 var entityDate = DateKey.Parse(entity.PartitionKey);
                 var before = new DateKey(entityDate.Date.AddDays(-1));

--- a/Dashboard.Storage/Azure/BuildUtil.cs
+++ b/Dashboard.Storage/Azure/BuildUtil.cs
@@ -41,16 +41,6 @@ namespace Dashboard.Azure
             return _buildResultDateTable.ExecuteQuery(query).ToList();
         }
 
-        public List<BuildResultEntity> GetBuildResults(DateTimeOffset startDate, ClassificationKind kind, string viewName)
-        {
-            var filter = FilterUtil
-                .SinceDate(ColumnNames.PartitionKey, startDate)
-                .And(FilterUtil.Column(nameof(BuildResultEntity.ClassificationKindRaw), kind.ToString()));
-            filter = FilterView(filter, viewName);
-            var query = new TableQuery<BuildResultEntity>().Where(filter);
-            return _buildResultDateTable.ExecuteQuery(query).ToList();
-        }
-
         public List<BuildResultEntity> GetBuildResultsByKindName(DateTimeOffset startDate, string kindName, string viewName)
         {
             var filter = FilterUtil

--- a/Dashboard.Storage/Azure/BuildUtil.cs
+++ b/Dashboard.Storage/Azure/BuildUtil.cs
@@ -51,6 +51,16 @@ namespace Dashboard.Azure
             return _buildResultDateTable.ExecuteQuery(query).ToList();
         }
 
+        public List<BuildResultEntity> GetBuildResultsByKindName(DateTimeOffset startDate, string kindName, string viewName)
+        {
+            var filter = FilterUtil
+                .SinceDate(ColumnNames.PartitionKey, startDate)
+                .And(FilterUtil.Column(nameof(BuildResultEntity.ClassificationName), kindName));
+            filter = FilterView(filter, viewName);
+            var query = new TableQuery<BuildResultEntity>().Where(filter);
+            return _buildResultDateTable.ExecuteQuery(query).ToList();
+        }
+
         public List<BuildFailureEntity> GetTestCaseFailures(DateTimeOffset startDate, string viewName)
         {
             var filter = FilterUtil

--- a/Dashboard/Controllers/BuildsController.cs
+++ b/Dashboard/Controllers/BuildsController.cs
@@ -106,16 +106,15 @@ namespace Dashboard.Controllers
 
         public ActionResult Kind(string kind = null, bool pr = false, DateTime? startDate = null, string viewName = AzureUtil.ViewNameRoslyn)
         {
-            var kindValue = EnumUtil.Parse(kind, ClassificationKind.Unknown);
             var startDateValue = startDate ?? DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
             var list = _buildUtil
-                .GetBuildResults(startDateValue, kindValue, viewName)
+                .GetBuildResultsByKindName(startDateValue, kind, viewName)
                 .Where(x => pr || !JobUtil.IsPullRequestJobName(x.JobName))
                 .ToList();
             var model = new BuildResultKindModel()
             {
                 IncludePullRequests = pr,
-                ClassificationKind = kindValue.ToString(),
+                ClassificationKind = kind,
                 Entries = list,
                 StartDate = startDateValue,
                 SelectedViewName = viewName
@@ -125,10 +124,9 @@ namespace Dashboard.Controllers
 
         public ActionResult KindByViewName(string kind = null, bool pr = false, DateTime? startDate = null)
         {
-            var kindValue = EnumUtil.Parse(kind, ClassificationKind.Unknown);
             var startDateValue = startDate ?? DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
             var results =
-                _buildUtil.GetBuildResults(startDateValue, kindValue, AzureUtil.ViewNameAll)
+                _buildUtil.GetBuildResultsByKindName(startDateValue, kind, AzureUtil.ViewNameAll)
                 .Where(x => pr || !JobUtil.IsPullRequestJobName(x.JobId))
                 .ToList();
             var builds = results
@@ -138,7 +136,7 @@ namespace Dashboard.Controllers
             var model = new BuildResultKindByViewNameModel()
             {
                 IncludePullRequests = pr,
-                ClassificationKind = kindValue.ToString(),
+                ClassificationKind = kind,
                 StartDate = startDateValue,
                 Builds = builds,
                 TotalResultCount = results.Count


### PR DESCRIPTION
When clicking on bars in the `/builds/view` graph, certain "kind" categories were broken and would redirect to the "Unknown" category instead of the proper kind category. This turned out to be an issue in the way the kind string was parsed into an internal `ClassificationKind` type by the backend.

This PR addresses the issue by filtering build results using the `ClassificationName` column instead of the `ClassificationKindRaw` column. This approach is guaranteed to be a view-only change, and since the `ClassificationName` column is the source of the values that are subsequently used for filtering results, there should be no more mismatch issues with "kind" on these pages.